### PR TITLE
Add purchase date and total prices to record model

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 from utils.components import RecordGroup
 from utils.streamlit_util import remove_streamlit_style
+from utils.collection_util import group_and_count, group_and_sum
 from models.record import Record
 import streamlit as st
 
@@ -49,7 +50,18 @@ class App:
     @staticmethod
     def sort_func(x: Record, tag_list):
         return ''.join([str(getattr(x, tag, '')) for tag in tag_list])
-    
+
+
+    def generate_summary_string(self):
+        total_count_by_format = group_and_count([record.format for record in self.data])
+        total_price_by_currency = group_and_sum([record.purchase_price for record in self.data if record.purchase_price is not None])
+
+        total_count_by_format_as_string = "".join([f"{count} {format}s, " for format, count in total_count_by_format.items()])[:-2]
+        total_price_by_currency_as_string = "".join([f"{currency} {price}, " for currency, price in total_price_by_currency.items()])[:-2]
+
+        return f'Totally {total_count_by_format_as_string}' + (f' and {total_price_by_currency_as_string}' if total_price_by_currency_as_string else '')
+
+
     def run(self):
         st.title('Records')
         summary = st.empty()
@@ -114,9 +126,10 @@ class App:
             record_widget.generate()
 
         if search:
-            summary.markdown(f'Found {sum([len(records) for records in table.values()])} records for "{search}"')
+            summary_string = f'Found {sum([len(records) for records in table.values()])} records for "{search}"'
         else:
-            summary.markdown(f'Totally {"".join([f"{count[format]} {format}s, " for format in count])[:-2]}')
+            summary_string = self.generate_summary_string()
+        summary.markdown(summary_string)
 
         st.sidebar.write("Developed by [@BayernMuller](https://github.com/bayernmuller)")
         st.sidebar.write("Fork this template from [here](https://github.com/BayernMuller/vinyl/fork) and make your own list!")

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from utils.components import RecordGroup
 from utils.streamlit_util import remove_streamlit_style
 from utils.collection_util import group_and_count, group_and_sum
+from utils.locale_util import format_currency 
 from models.record import Record
 from typing import Optional
 import streamlit as st
@@ -59,7 +60,7 @@ class App:
 
         if group_name == 'purchase_date':
             total_price_by_currency = group_and_sum([record.purchase_price for record in self.data if record.purchase_price is not None])
-            total_price_by_currency_as_string = "".join([f"{currency} {price}, " for currency, price in total_price_by_currency.items()])[:-2]
+            total_price_by_currency_as_string = "".join([f"{format_currency(price, currency)}, " for currency, price in total_price_by_currency.items()])[:-2]
         else:
             total_price_by_currency_as_string = ''
 

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from utils.components import RecordGroup
 from utils.streamlit_util import remove_streamlit_style
 from utils.collection_util import group_and_count, group_and_sum
 from models.record import Record
+from typing import Optional
 import streamlit as st
 
 RECORDS_LIST_FILE = 'list.json'
@@ -52,12 +53,15 @@ class App:
         return ''.join([str(getattr(x, tag, '')) for tag in tag_list])
 
 
-    def generate_summary_string(self):
+    def generate_summary_string(self, group_name: Optional[str] = None):
         total_count_by_format = group_and_count([record.format for record in self.data])
-        total_price_by_currency = group_and_sum([record.purchase_price for record in self.data if record.purchase_price is not None])
-
         total_count_by_format_as_string = "".join([f"{count} {format}s, " for format, count in total_count_by_format.items()])[:-2]
-        total_price_by_currency_as_string = "".join([f"{currency} {price}, " for currency, price in total_price_by_currency.items()])[:-2]
+
+        if group_name == 'purchase_date':
+            total_price_by_currency = group_and_sum([record.purchase_price for record in self.data if record.purchase_price is not None])
+            total_price_by_currency_as_string = "".join([f"{currency} {price}, " for currency, price in total_price_by_currency.items()])[:-2]
+        else:
+            total_price_by_currency_as_string = ''
 
         return f'Totally {total_count_by_format_as_string}' + (f' and {total_price_by_currency_as_string}' if total_price_by_currency_as_string else '')
 
@@ -128,7 +132,7 @@ class App:
         if search:
             summary_string = f'Found {sum([len(records) for records in table.values()])} records for "{search}"'
         else:
-            summary_string = self.generate_summary_string()
+            summary_string = self.generate_summary_string(group_name=group_name)
         summary.markdown(summary_string)
 
         st.sidebar.write("Developed by [@BayernMuller](https://github.com/bayernmuller)")

--- a/main.py
+++ b/main.py
@@ -60,6 +60,7 @@ class App:
             'format': {'sort_by': ['artist', 'year'], },
             'year': {'sort_by': ['artist', 'title'], },
             'country': {'sort_by': ['artist', 'year'], },
+            'purchase_date': {'sort_by': ['purchase_date', 'artist', 'year'], },
             'none': {'sort_by': ['artist', 'year'], },
         }
 
@@ -75,6 +76,11 @@ class App:
                 continue
 
             group = getattr(record, group_name, 'unknown')
+
+            # get the year from purchase_date
+            if group_name == 'purchase_date':
+                group = group[:4] if group else 'N/A'
+
             if group not in table:
                 table[group] = []
             table[group].append(record)
@@ -91,14 +97,13 @@ class App:
                 st.info('No records found')
             st.stop()
 
-
         count = {}
         for group, records in table.items():
             st.write('---')
             if group_name != 'none':
                 st.subheader(group)
 
-            record_widget = RecordGroup()
+            record_widget = RecordGroup(group_name)
             for record in records:
                 record_widget.add_record(record)
                 if record.format not in count:

--- a/models/purchase_info.py
+++ b/models/purchase_info.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class PurchaseInfo(BaseModel):
+    date: Optional[str] = None
+    currency: Optional[str] = None
+    price: Optional[float] = None
+    store: Optional[str] = None
+
+    def __init__(self, **data):
+        super().__init__(**data)
+
+        # validate the purchase
+        if self.price and not self.currency:
+            self.currency = 'USD'
+
+    def __str__(self):
+        return f'{self.date} {self.price} {self.currency} {self.store}'

--- a/models/purchase_info.py
+++ b/models/purchase_info.py
@@ -5,7 +5,7 @@ class PurchaseInfo(BaseModel):
     date: Optional[str] = None
     currency: Optional[str] = None
     price: Optional[float] = None
-    store: Optional[str] = None
+    location: Optional[str] = None
 
     def __init__(self, **data):
         super().__init__(**data)
@@ -15,4 +15,4 @@ class PurchaseInfo(BaseModel):
             self.currency = 'USD'
 
     def __str__(self):
-        return f'{self.date} {self.price} {self.currency} {self.store}'
+        return f'{self.date} {self.price} {self.currency} {self.location}'

--- a/models/record.py
+++ b/models/record.py
@@ -34,9 +34,9 @@ class Record(BaseModel):
         return (currency, price) if price and currency else None
     
     @property
-    def purchase_store(self) -> Optional[str]:
+    def purchase_location(self) -> Optional[str]:
         if self.purchase:
-            return self.purchase.store
+            return self.purchase.location
         return None
 
     def __str__(self):

--- a/models/record.py
+++ b/models/record.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel
-from typing import List, Optional
+from typing import List, Tuple, Optional
+
+DEFAULT_CURRENCY = 'USD'
 
 class Record(BaseModel):
     # required
@@ -12,13 +14,34 @@ class Record(BaseModel):
 
     # optional
     country: Optional[str] = 'N/A'
-    purchase: Optional[dict]
+    purchase: Optional[dict] = {}
+
+    # constructor
+    def __init__(self, **data):
+        super().__init__(**data)
+
+        # validate the purchase
+        if self.purchase:
+            if 'price' in self.purchase and 'currency' not in self.purchase:
+                self.purchase['currency'] = DEFAULT_CURRENCY
 
     @property
     def purchase_date(self) -> Optional[str]:
         if self.purchase:
             return self.purchase.get('date')
         return None
+    
+    @property
+    def purchase_price(self) -> Optional[Tuple[str, float]]:
+        if self.purchase is None or 'price' not in self.purchase:
+            return None
+
+        currency = self.purchase.get('currency')
+        price = self.purchase.get('price')
+        if price == 0:
+            return None
+
+        return (currency, price) if price and currency else None
 
     def __str__(self):
         return f'{self.artist} {self.title} {self.year} {self.format}'

--- a/models/record.py
+++ b/models/record.py
@@ -12,6 +12,13 @@ class Record(BaseModel):
 
     # optional
     country: Optional[str] = 'N/A'
+    purchase: Optional[dict]
+
+    @property
+    def purchase_date(self) -> Optional[str]:
+        if self.purchase:
+            return self.purchase.get('date')
+        return None
 
     def __str__(self):
         return f'{self.artist} {self.title} {self.year} {self.format}'

--- a/models/record.py
+++ b/models/record.py
@@ -42,6 +42,12 @@ class Record(BaseModel):
             return None
 
         return (currency, price) if price and currency else None
+    
+    @property
+    def purchase_store(self) -> Optional[str]:
+        if self.purchase:
+            return self.purchase.get('store')
+        return None
 
     def __str__(self):
         return f'{self.artist} {self.title} {self.year} {self.format}'

--- a/models/record.py
+++ b/models/record.py
@@ -1,7 +1,6 @@
 from pydantic import BaseModel
 from typing import List, Tuple, Optional
-
-DEFAULT_CURRENCY = 'USD'
+from models.purchase_info import PurchaseInfo
 
 class Record(BaseModel):
     # required
@@ -14,30 +13,21 @@ class Record(BaseModel):
 
     # optional
     country: Optional[str] = 'N/A'
-    purchase: Optional[dict] = {}
-
-    # constructor
-    def __init__(self, **data):
-        super().__init__(**data)
-
-        # validate the purchase
-        if self.purchase:
-            if 'price' in self.purchase and 'currency' not in self.purchase:
-                self.purchase['currency'] = DEFAULT_CURRENCY
+    purchase: Optional[PurchaseInfo] = None
 
     @property
     def purchase_date(self) -> Optional[str]:
         if self.purchase:
-            return self.purchase.get('date')
+            return self.purchase.date
         return None
     
     @property
     def purchase_price(self) -> Optional[Tuple[str, float]]:
-        if self.purchase is None or 'price' not in self.purchase:
+        if self.purchase is None or self.purchase.price is None:
             return None
 
-        currency = self.purchase.get('currency')
-        price = self.purchase.get('price')
+        currency = self.purchase.currency
+        price = self.purchase.price
         if price == 0:
             return None
 
@@ -46,7 +36,7 @@ class Record(BaseModel):
     @property
     def purchase_store(self) -> Optional[str]:
         if self.purchase:
-            return self.purchase.get('store')
+            return self.purchase.store
         return None
 
     def __str__(self):

--- a/utils/collection_util.py
+++ b/utils/collection_util.py
@@ -1,0 +1,19 @@
+from collections import defaultdict
+from typing import List, Dict, Tuple
+
+def group_and_count(tuple_list: List[str]) -> Dict[str, int]:
+    totals = defaultdict(int)
+
+    for value in tuple_list:
+        totals[value] += 1
+
+    return totals
+
+
+def group_and_sum(tuple_list: List[Tuple[str, float]]) -> Dict[str, float]:
+    totals = defaultdict(float)
+
+    for key, value in tuple_list:
+        totals[key] += value
+
+    return totals

--- a/utils/components.py
+++ b/utils/components.py
@@ -1,12 +1,14 @@
 from dataclasses import dataclass
 from models.record import Record
+from typing import Optional
 import streamlit as st
 import base64
 
 class RecordGroup:
-    def __init__(self):
+    def __init__(self, group_name: Optional[str] = None):
         self.__html = '<div>'
         self.__length = 0
+        self.__group_name = group_name
 
     def add_record(self, record: Record):
         self.__html += self.__create_record(record)
@@ -44,6 +46,9 @@ class RecordGroup:
             <span>•</span>
             <text>{record.format}</text>
         </div>
+        {f'''<div style="color: gray; font-size: 12px;">
+            <text>{record.purchase_date}</text>
+        </div>''' if record.purchase_date and self.__group_name == 'purchase_date' else '<div></div>'}
     </div>
 </div>
     """

--- a/utils/components.py
+++ b/utils/components.py
@@ -37,7 +37,7 @@ class RecordGroup:
         html = f"""
 <div style="display: inline-block; width: 150px; height: 260; margin: 0px 10px 10px 0px; vertical-align: top;">
     <img width="150" height="150" src="{record.cover}" style="border-radius: 7px;"/>
-    <div class="vynil-info">
+    <div class="vinyl-info">
         <b>{record.title}</b>
         <div style="color: gray; font-size: 12px;">
             <text>{record.artist}</text>
@@ -46,10 +46,30 @@ class RecordGroup:
             <span>•</span>
             <text>{record.format}</text>
         </div>
-        {f'''<div style="color: gray; font-size: 12px;">
-            <text>{record.purchase_date}</text>
-        </div>''' if record.purchase_date and self.__group_name == 'purchase_date' else '<div></div>'}
+        {self.__create_purchase_info(record)}
     </div>
 </div>
     """
         return html
+
+    def __create_purchase_info(self, record: Record) -> str:
+        if not record.purchase or self.__group_name != 'purchase_date':
+            return '<div></div>'
+
+        price_html = f"""<div style="color: gray; font-size: 12px;">
+            <text>💵 {f'{record.purchase_price[0]} {record.purchase_price[1]}'}</text>
+        </div>""" if record.purchase_price else '<div></div>'
+
+
+        others = [
+            f'<text>{value}</text>' for value in [
+                f'{record.purchase_store}' if record.purchase_store else None,
+                f'{record.purchase_date}' if record.purchase_date else None,
+            ] if value
+        ]
+        others_html = f"""<div style="color: gray; font-size: 12px;">
+            <text>🛒 </text>
+            {"<span>•</span>".join(others)}
+        </div>""" if others else '<div></div>'
+
+        return f"{price_html}{others_html}"

--- a/utils/components.py
+++ b/utils/components.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from models.record import Record
+from utils.locale_util import format_currency 
 from typing import Optional
 import streamlit as st
 import base64
@@ -57,7 +58,7 @@ class RecordGroup:
             return '<div></div>'
 
         price_html = f"""<div style="color: gray; font-size: 12px;">
-            <text>💵 {f'{record.purchase_price[0]} {record.purchase_price[1]}'}</text>
+            <text>💵 {f'{format_currency(record.purchase_price[1], record.purchase_price[0])}'}</text>
         </div>""" if record.purchase_price else '<div></div>'
 
 

--- a/utils/components.py
+++ b/utils/components.py
@@ -64,7 +64,7 @@ class RecordGroup:
 
         others = [
             f'<text>{value}</text>' for value in [
-                f'{record.purchase_store}' if record.purchase_store else None,
+                f'{record.purchase_location}' if record.purchase_location else None,
                 f'{record.purchase_date}' if record.purchase_date else None,
             ] if value
         ]

--- a/utils/components.py
+++ b/utils/components.py
@@ -58,14 +58,14 @@ class RecordGroup:
             return '<div></div>'
 
         price_html = f"""<div style="color: gray; font-size: 12px;">
-            <text>💵 {f'{format_currency(record.purchase_price[1], record.purchase_price[0])}'}</text>
+            <text>💵 {format_currency(record.purchase_price[1], record.purchase_price[0])}</text>
         </div>""" if record.purchase_price else '<div></div>'
 
 
         others = [
             f'<text>{value}</text>' for value in [
-                f'{record.purchase_location}' if record.purchase_location else None,
-                f'{record.purchase_date}' if record.purchase_date else None,
+                record.purchase_location if record.purchase_location else None,
+                record.purchase_date if record.purchase_date else None,
             ] if value
         ]
         others_html = f"""<div style="color: gray; font-size: 12px;">

--- a/utils/locale_util.py
+++ b/utils/locale_util.py
@@ -1,0 +1,20 @@
+import locale
+
+def currency_to_locale(currency: str):
+    if currency == 'USD':
+        return 'en_US.UTF-8'
+    elif currency == 'EUR':
+        return 'de_DE.UTF-8'
+    elif currency == 'GBP':
+        return 'en_GB.UTF-8'
+    elif currency == 'JPY':
+        return 'ja_JP.UTF-8'
+    elif currency == 'KRW':
+        return 'ko_KR.UTF-8'
+    # implement other currencies if needed
+    else:
+        return 'en_US.UTF-8'
+
+def format_currency(value: float, currency: str):
+    locale.setlocale(locale.LC_ALL, currency_to_locale(currency))
+    return locale.currency(value, symbol=True, grouping=True)


### PR DESCRIPTION
This pull request adds the `purchase_date` property to the `Record` model, which retrieves the purchase date from the `purchase` dictionary. It also adds the `purchase_price` property, which retrieves the purchase price and currency from the `purchase` dictionary. Additionally, it includes a new method `generate_summary_string` in the `RecordGroup` class, which generates a summary string with the total count of records by format and the total price by currency.

<img width="384" alt="image" src="https://github.com/BayernMuller/vinyl/assets/16515307/654423c8-6874-4569-b4db-86071bf0a738">
