### PR TITLE
Add purchase_location and purchase_price options

### DIFF
--- a/main.py
+++ b/main.py
@@ -58,7 +58,7 @@ class App:
         total_count_by_format = group_and_count([record.format for record in self.data])
         total_count_by_format_as_string = "".join([f"{count} {format}s, " for format, count in total_count_by_format.items()])[:-2]
 
-        if group_name == 'purchase_date':
+        if group_name == 'purchase_date' or group_name == 'purchase_location':
             total_price_by_currency = group_and_sum([record.purchase_price for record in self.data if record.purchase_price is not None])
             total_price_by_currency_as_string = "".join([f"{format_currency(price, currency)}, " for currency, price in total_price_by_currency.items()])[:-2]
         else:
@@ -78,6 +78,7 @@ class App:
             'year': {'sort_by': ['artist', 'title'], },
             'country': {'sort_by': ['artist', 'year'], },
             'purchase_date': {'sort_by': ['purchase_date', 'artist', 'year'], },
+            'purchase_location': {'sort_by': ['purchase_date', 'artist', 'year'], },
             'none': {'sort_by': ['artist', 'year'], },
         }
 

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from utils.collection_util import group_and_count, group_and_sum
 from babel.numbers import format_currency
 from models.record import Record
 from typing import Optional
+from operator import attrgetter
 import streamlit as st
 
 RECORDS_LIST_FILE = 'list.json'
@@ -47,11 +48,6 @@ class App:
 
         self.filter = st.sidebar.expander('filter', expanded=True)
         self.options = st.sidebar.expander('options', expanded=True)
-                
-
-    @staticmethod
-    def sort_func(x: Record, tag_list):
-        return ''.join([str(getattr(x, tag, '')) for tag in tag_list])
 
 
     def generate_summary_string(self, group_name: Optional[str] = None):
@@ -102,7 +98,7 @@ class App:
             if group not in table:
                 table[group] = []
             table[group].append(record)
-            table[group] = sorted(table[group], key=lambda x: App.sort_func(x, sort_by))
+            table[group] = sorted(table[group], key=attrgetter(*sort_by))
 
         disable_order = group_name == 'none' or len(table) == 1
         group_order = self.options.radio('order', ['ascending', 'descending'], index=0, key='order', horizontal=True, disabled=disable_order)

--- a/main.py
+++ b/main.py
@@ -54,13 +54,44 @@ class App:
         total_count_by_format = group_and_count([record.format for record in self.data])
         total_count_by_format_as_string = "".join([f"{count} {format}s, " for format, count in total_count_by_format.items()])[:-2]
 
-        if group_name == 'purchase_date' or group_name == 'purchase_location':
+        if group_name in ['purchase_price', 'purchase_date', 'purchase_location']:
             total_price_by_currency = group_and_sum([record.purchase_price for record in self.data if record.purchase_price is not None])
             total_price_by_currency_as_string = "".join([f"{format_currency(price, currency)}, " for currency, price in total_price_by_currency.items()])[:-2]
         else:
             total_price_by_currency_as_string = ''
 
         return f'Totally {total_count_by_format_as_string}' + (f' and {total_price_by_currency_as_string}' if total_price_by_currency_as_string else '')
+
+
+    def genenerate_group_key(self, record: Record, group_name: str) -> str:
+        group = getattr(record, group_name, 'N/A')
+
+        # get the year from purchase_date
+        if group_name == 'purchase_date':
+            group = group[:4] if group else 'N/A'
+
+        # get range from purchase_price
+        if group_name == 'purchase_price':
+            # 10, 20, ..., 100, 200, ..., 1000, 2000, ..., 10000, 20000, ..., 100000, 200000, ..., 1000000
+            max_digit = 6 # 1,000,000
+            ranges = [ 
+                x 
+                for digit in range(1, max_digit+1) 
+                for x in range(10**digit, 10**(digit+1), 10**digit) 
+            ] + [ 10**max_digit ]
+
+            currency, price = group
+            if price < ranges[0]:
+                group = f'~ {format_currency(10, currency)}'
+            else:
+                for i in range(len(ranges) - 1):
+                    if price < ranges[i+1]:
+                        group = f'{format_currency(ranges[i], currency)} ~'
+                        break
+                else:
+                    group = f'{format_currency(ranges[-1], currency)} ~'
+
+        return group
 
 
     def run(self):
@@ -73,6 +104,7 @@ class App:
             'format': {'sort_by': ['artist', 'year'], },
             'year': {'sort_by': ['artist', 'title'], },
             'country': {'sort_by': ['artist', 'year'], },
+            'purchase_price': {'sort_by': ['purchase_price', 'purchase_date'], },
             'purchase_date': {'sort_by': ['purchase_date', 'artist', 'year'], },
             'purchase_location': {'sort_by': ['purchase_date', 'artist', 'year'], },
             'none': {'sort_by': ['artist', 'year'], },
@@ -92,22 +124,23 @@ class App:
         ] if search else self.data
         records = sorted(records, key=attrgetter(*sort_by))
 
-        # group and sort records by options
+        # group by options
         table = {}
         for record in records:
-            group = getattr(record, group_name, 'unknown')
-
-            # get the year from purchase_date
-            if group_name == 'purchase_date':
-                group = group[:4] if group else 'N/A'
-
+            group = self.genenerate_group_key(record, group_name)
             if group not in table:
                 table[group] = []
             table[group].append(record)
 
+        # sort keys by options
         disable_order = group_name == 'none' or len(table) == 1
         group_order = self.options.radio('order', ['ascending', 'descending'], index=0, key='order', horizontal=True, disabled=disable_order)
-        table = dict(sorted(table.items(), key=lambda x: x[0], reverse=group_order == 'descending'))
+        table = dict(sorted(
+            table.items(), 
+            # natural sort (https://stackoverflow.com/a/31432964) for purchase_price
+            key=lambda x: '{0:0>12}'.format(x[0]).lower() if group_name == 'purchase_price' else x[0],
+            reverse=group_order == 'descending',
+        ))
 
         # no records found
         if len(table) == 0:

--- a/utils/components.py
+++ b/utils/components.py
@@ -9,7 +9,7 @@ class RecordGroup:
     def __init__(self, group_name: Optional[str] = None):
         self.__html = '<div>'
         self.__length = 0
-        self.__show_purchase_info = group_name == 'purchase_date' or group_name == 'purchase_location'
+        self.__show_purchase_info = group_name in ['purchase_price', 'purchase_date', 'purchase_location']
 
     def add_record(self, record: Record):
         self.__html += self.__create_record(record)

--- a/utils/components.py
+++ b/utils/components.py
@@ -9,7 +9,7 @@ class RecordGroup:
     def __init__(self, group_name: Optional[str] = None):
         self.__html = '<div>'
         self.__length = 0
-        self.__group_name = group_name
+        self.__show_purchase_info = group_name == 'purchase_date' or group_name == 'purchase_location'
 
     def add_record(self, record: Record):
         self.__html += self.__create_record(record)
@@ -54,7 +54,7 @@ class RecordGroup:
         return html
 
     def __create_purchase_info(self, record: Record) -> str:
-        if not record.purchase or self.__group_name != 'purchase_date':
+        if not record.purchase or not self.__show_purchase_info:
             return '<div></div>'
 
         price_html = f"""<div style="color: gray; font-size: 12px;">


### PR DESCRIPTION
This pull request adds two new options, `purchase_location` and `purchase_price`, to the existing record filtering and sorting logic. It also includes refactoring of the record grouping and display logic.

#### `purchase_location`
<img width="1021" alt="image" src="https://github.com/BayernMuller/vinyl/assets/16515307/5a3159a6-9a81-4d01-b49a-d0a9b88b0570">

#### `purchase_price`
<img width="696" alt="image" src="https://github.com/BayernMuller/vinyl/assets/16515307/9447db50-702c-4690-a9b7-9110dac1a9dc">
